### PR TITLE
refactor: reduce function complexity for C90 McCabe compliance

### DIFF
--- a/src/claude_teams/tasks.py
+++ b/src/claude_teams/tasks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import json
 from collections import deque
+import json
 from pathlib import Path
 from typing import Any
 
@@ -24,9 +24,7 @@ def _flush_pending_writes(pending_writes: dict[Path, TaskFile]) -> None:
         path.write_text(json.dumps(task_obj.model_dump(by_alias=True, exclude_none=True)))
 
 
-def _would_create_cycle(
-    team_dir: Path, from_id: str, to_id: str, pending_edges: dict[str, set[str]]
-) -> bool:
+def _would_create_cycle(team_dir: Path, from_id: str, to_id: str, pending_edges: dict[str, set[str]]) -> bool:
     """True if making from_id blocked_by to_id creates a cycle.
 
     BFS from to_id through blocked_by chains (on-disk + pending);
@@ -92,13 +90,222 @@ def create_task(
     return task
 
 
-def get_task(
-    team_name: str, task_id: str, base_dir: Path | None = None
-) -> TaskFile:
+def get_task(team_name: str, task_id: str, base_dir: Path | None = None) -> TaskFile:
     team_dir = _tasks_dir(base_dir) / team_name
     fpath = team_dir / f"{task_id}.json"
     raw = json.loads(fpath.read_text())
     return TaskFile(**raw)
+
+
+def _read_or_pending(path: Path, pending_writes: dict[Path, TaskFile]) -> TaskFile:
+    """Read a task from pending_writes cache or disk."""
+    if path in pending_writes:
+        return pending_writes[path]
+    return TaskFile(**json.loads(path.read_text()))
+
+
+def _iter_task_files(team_dir: Path, exclude_id: str) -> list[Path]:
+    """List task JSON files in team_dir, excluding the given task ID."""
+    result = []
+    for f in team_dir.glob("*.json"):
+        try:
+            int(f.stem)
+        except ValueError:
+            continue
+        if f.stem != exclude_id:
+            result.append(f)
+    return result
+
+
+def _validate_edge_refs(team_dir: Path, task_id: str, ids: list[str], self_error_msg: str) -> None:
+    """Validate that edge target IDs are not self-referencing and exist on disk."""
+    for b in ids:
+        if b == task_id:
+            raise ValueError(self_error_msg)
+        if not (team_dir / f"{b}.json").exists():
+            raise ValueError(f"Referenced task {b!r} does not exist")
+
+
+def _build_pending_edges(
+    team_dir: Path,
+    task_id: str,
+    add_blocks: list[str] | None,
+    add_blocked_by: list[str] | None,
+) -> dict[str, set[str]]:
+    """Validate refs exist and build pending edge map for cycle detection."""
+    pending_edges: dict[str, set[str]] = {}
+    if add_blocks:
+        _validate_edge_refs(team_dir, task_id, add_blocks, f"Task {task_id} cannot block itself")
+        for b in add_blocks:
+            pending_edges.setdefault(b, set()).add(task_id)
+    if add_blocked_by:
+        _validate_edge_refs(team_dir, task_id, add_blocked_by, f"Task {task_id} cannot be blocked by itself")
+        for b in add_blocked_by:
+            pending_edges.setdefault(task_id, set()).add(b)
+    return pending_edges
+
+
+def _check_no_cycles(
+    team_dir: Path,
+    task_id: str,
+    add_blocks: list[str] | None,
+    add_blocked_by: list[str] | None,
+    pending_edges: dict[str, set[str]],
+) -> None:
+    """Check that proposed edges would not create cycles."""
+    if add_blocks:
+        for b in add_blocks:
+            if _would_create_cycle(team_dir, b, task_id, pending_edges):
+                raise ValueError(f"Adding block {task_id} -> {b} would create a circular dependency")
+    if add_blocked_by:
+        for b in add_blocked_by:
+            if _would_create_cycle(team_dir, task_id, b, pending_edges):
+                raise ValueError(f"Adding dependency {task_id} blocked_by {b} would create a circular dependency")
+
+
+def _validate_status_transition(
+    team_dir: Path,
+    task: TaskFile,
+    status: str,
+    add_blocked_by: list[str] | None,
+) -> None:
+    """Validate that a status transition is allowed."""
+    cur_order = _STATUS_ORDER[task.status]
+    new_order = _STATUS_ORDER.get(status)
+    if new_order is None:
+        raise ValueError(f"Invalid status: {status!r}")
+    if new_order < cur_order:
+        raise ValueError(f"Cannot transition from {task.status!r} to {status!r}")
+    effective_blocked_by = set(task.blocked_by)
+    if add_blocked_by:
+        effective_blocked_by.update(add_blocked_by)
+    if status in ("in_progress", "completed") and effective_blocked_by:
+        for blocker_id in effective_blocked_by:
+            blocker_path = team_dir / f"{blocker_id}.json"
+            if blocker_path.exists():
+                blocker = TaskFile(**json.loads(blocker_path.read_text()))
+                if blocker.status != "completed":
+                    raise ValueError(
+                        f"Cannot set status to {status!r}: blocked by task {blocker_id} (status: {blocker.status!r})"
+                    )
+
+
+def _apply_edges(
+    team_dir: Path,
+    task: TaskFile,
+    task_id: str,
+    add_blocks: list[str] | None,
+    add_blocked_by: list[str] | None,
+    pending_writes: dict[Path, TaskFile],
+) -> None:
+    """Apply add_blocks/add_blocked_by to task and related tasks (in-memory)."""
+    if add_blocks:
+        existing = set(task.blocks)
+        for b in add_blocks:
+            if b not in existing:
+                task.blocks.append(b)
+                existing.add(b)
+            b_path = team_dir / f"{b}.json"
+            other = _read_or_pending(b_path, pending_writes)
+            if task_id not in other.blocked_by:
+                other.blocked_by.append(task_id)
+            pending_writes[b_path] = other
+    if add_blocked_by:
+        existing = set(task.blocked_by)
+        for b in add_blocked_by:
+            if b not in existing:
+                task.blocked_by.append(b)
+                existing.add(b)
+            b_path = team_dir / f"{b}.json"
+            other = _read_or_pending(b_path, pending_writes)
+            if task_id not in other.blocks:
+                other.blocks.append(task_id)
+            pending_writes[b_path] = other
+
+
+def _apply_metadata(task: TaskFile, metadata: dict[str, Any]) -> None:
+    """Merge metadata into task, removing keys set to None."""
+    current = task.metadata or {}
+    for k, v in metadata.items():
+        if v is None:
+            current.pop(k, None)
+        else:
+            current[k] = v
+    task.metadata = current if current else None
+
+
+def _clean_references_on_complete(team_dir: Path, task_id: str, pending_writes: dict[Path, TaskFile]) -> None:
+    """Remove task_id from blocked_by lists of other tasks when completed."""
+    for f in _iter_task_files(team_dir, task_id):
+        other = _read_or_pending(f, pending_writes)
+        if task_id in other.blocked_by:
+            other.blocked_by.remove(task_id)
+            pending_writes[f] = other
+
+
+def _clean_references_on_delete(team_dir: Path, task_id: str, pending_writes: dict[Path, TaskFile]) -> None:
+    """Remove task_id from both blocked_by and blocks lists of other tasks."""
+    for f in _iter_task_files(team_dir, task_id):
+        other = _read_or_pending(f, pending_writes)
+        changed = False
+        if task_id in other.blocked_by:
+            other.blocked_by.remove(task_id)
+            changed = True
+        if task_id in other.blocks:
+            other.blocks.remove(task_id)
+            changed = True
+        if changed:
+            pending_writes[f] = other
+
+
+def _apply_scalar_fields(
+    task: TaskFile,
+    subject: str | None,
+    description: str | None,
+    active_form: str | None,
+    owner: str | None,
+) -> None:
+    """Apply simple scalar field updates to task."""
+    if subject is not None:
+        task.subject = subject
+    if description is not None:
+        task.description = description
+    if active_form is not None:
+        task.active_form = active_form
+    if owner is not None:
+        task.owner = owner
+
+
+def _apply_status_and_cleanup(
+    team_dir: Path,
+    task: TaskFile,
+    task_id: str,
+    status: str | None,
+    pending_writes: dict[Path, TaskFile],
+) -> None:
+    """Apply status change and clean up references in other tasks."""
+    if status is not None and status != "deleted":
+        task.status = status
+        if status == "completed":
+            _clean_references_on_complete(team_dir, task_id, pending_writes)
+    elif status == "deleted":
+        task.status = "deleted"
+        _clean_references_on_delete(team_dir, task_id, pending_writes)
+
+
+def _write_task_updates(
+    fpath: Path,
+    task: TaskFile,
+    status: str | None,
+    pending_writes: dict[Path, TaskFile],
+) -> None:
+    """Flush all pending writes and write/delete the main task file."""
+    if status == "deleted":
+        _flush_pending_writes(pending_writes)
+        fpath.unlink()
+    else:
+        fpath.write_text(json.dumps(task.model_dump(by_alias=True, exclude_none=True)))
+        _flush_pending_writes(pending_writes)
 
 
 def update_task(
@@ -120,175 +327,25 @@ def update_task(
     fpath = team_dir / f"{task_id}.json"
 
     with file_lock(lock_path):
-        # --- Phase 1: Read ---
         task = TaskFile(**json.loads(fpath.read_text()))
 
-        # --- Phase 2: Validate (no disk writes) ---
-        pending_edges: dict[str, set[str]] = {}
-
-        if add_blocks:
-            for b in add_blocks:
-                if b == task_id:
-                    raise ValueError(f"Task {task_id} cannot block itself")
-                if not (team_dir / f"{b}.json").exists():
-                    raise ValueError(f"Referenced task {b!r} does not exist")
-            for b in add_blocks:
-                pending_edges.setdefault(b, set()).add(task_id)
-
-        if add_blocked_by:
-            for b in add_blocked_by:
-                if b == task_id:
-                    raise ValueError(f"Task {task_id} cannot be blocked by itself")
-                if not (team_dir / f"{b}.json").exists():
-                    raise ValueError(f"Referenced task {b!r} does not exist")
-            for b in add_blocked_by:
-                pending_edges.setdefault(task_id, set()).add(b)
-
-        if add_blocks:
-            for b in add_blocks:
-                if _would_create_cycle(team_dir, b, task_id, pending_edges):
-                    raise ValueError(
-                        f"Adding block {task_id} -> {b} would create a circular dependency"
-                    )
-
-        if add_blocked_by:
-            for b in add_blocked_by:
-                if _would_create_cycle(team_dir, task_id, b, pending_edges):
-                    raise ValueError(
-                        f"Adding dependency {task_id} blocked_by {b} would create a circular dependency"
-                    )
-
+        pending_edges = _build_pending_edges(team_dir, task_id, add_blocks, add_blocked_by)
+        _check_no_cycles(team_dir, task_id, add_blocks, add_blocked_by, pending_edges)
         if status is not None and status != "deleted":
-            cur_order = _STATUS_ORDER[task.status]
-            new_order = _STATUS_ORDER.get(status)
-            if new_order is None:
-                raise ValueError(f"Invalid status: {status!r}")
-            if new_order < cur_order:
-                raise ValueError(
-                    f"Cannot transition from {task.status!r} to {status!r}"
-                )
-            effective_blocked_by = set(task.blocked_by)
-            if add_blocked_by:
-                effective_blocked_by.update(add_blocked_by)
-            if status in ("in_progress", "completed") and effective_blocked_by:
-                for blocker_id in effective_blocked_by:
-                    blocker_path = team_dir / f"{blocker_id}.json"
-                    if blocker_path.exists():
-                        blocker = TaskFile(**json.loads(blocker_path.read_text()))
-                        if blocker.status != "completed":
-                            raise ValueError(
-                                f"Cannot set status to {status!r}: "
-                                f"blocked by task {blocker_id} (status: {blocker.status!r})"
-                            )
+            _validate_status_transition(team_dir, task, status, add_blocked_by)
 
-        # --- Phase 3: Mutate (in-memory only) ---
         pending_writes: dict[Path, TaskFile] = {}
-
-        if subject is not None:
-            task.subject = subject
-        if description is not None:
-            task.description = description
-        if active_form is not None:
-            task.active_form = active_form
-        if owner is not None:
-            task.owner = owner
-
-        if add_blocks:
-            existing = set(task.blocks)
-            for b in add_blocks:
-                if b not in existing:
-                    task.blocks.append(b)
-                    existing.add(b)
-                b_path = team_dir / f"{b}.json"
-                if b_path in pending_writes:
-                    other = pending_writes[b_path]
-                else:
-                    other = TaskFile(**json.loads(b_path.read_text()))
-                if task_id not in other.blocked_by:
-                    other.blocked_by.append(task_id)
-                pending_writes[b_path] = other
-
-        if add_blocked_by:
-            existing = set(task.blocked_by)
-            for b in add_blocked_by:
-                if b not in existing:
-                    task.blocked_by.append(b)
-                    existing.add(b)
-                b_path = team_dir / f"{b}.json"
-                if b_path in pending_writes:
-                    other = pending_writes[b_path]
-                else:
-                    other = TaskFile(**json.loads(b_path.read_text()))
-                if task_id not in other.blocks:
-                    other.blocks.append(task_id)
-                pending_writes[b_path] = other
-
+        _apply_scalar_fields(task, subject, description, active_form, owner)
+        _apply_edges(team_dir, task, task_id, add_blocks, add_blocked_by, pending_writes)
         if metadata is not None:
-            current = task.metadata or {}
-            for k, v in metadata.items():
-                if v is None:
-                    current.pop(k, None)
-                else:
-                    current[k] = v
-            task.metadata = current if current else None
-
-        if status is not None and status != "deleted":
-            task.status = status
-            if status == "completed":
-                for f in team_dir.glob("*.json"):
-                    try:
-                        int(f.stem)
-                    except ValueError:
-                        continue
-                    if f.stem == task_id:
-                        continue
-                    if f in pending_writes:
-                        other = pending_writes[f]
-                    else:
-                        other = TaskFile(**json.loads(f.read_text()))
-                    if task_id in other.blocked_by:
-                        other.blocked_by.remove(task_id)
-                        pending_writes[f] = other
-
-        if status == "deleted":
-            task.status = "deleted"
-            for f in team_dir.glob("*.json"):
-                try:
-                    int(f.stem)
-                except ValueError:
-                    continue
-                if f.stem == task_id:
-                    continue
-                if f in pending_writes:
-                    other = pending_writes[f]
-                else:
-                    other = TaskFile(**json.loads(f.read_text()))
-                changed = False
-                if task_id in other.blocked_by:
-                    other.blocked_by.remove(task_id)
-                    changed = True
-                if task_id in other.blocks:
-                    other.blocks.remove(task_id)
-                    changed = True
-                if changed:
-                    pending_writes[f] = other
-
-        # --- Phase 4: Write ---
-        if status == "deleted":
-            _flush_pending_writes(pending_writes)
-            fpath.unlink()
-        else:
-            fpath.write_text(
-                json.dumps(task.model_dump(by_alias=True, exclude_none=True))
-            )
-            _flush_pending_writes(pending_writes)
+            _apply_metadata(task, metadata)
+        _apply_status_and_cleanup(team_dir, task, task_id, status, pending_writes)
+        _write_task_updates(fpath, task, status, pending_writes)
 
     return task
 
 
-def list_tasks(
-    team_name: str, base_dir: Path | None = None
-) -> list[TaskFile]:
+def list_tasks(team_name: str, base_dir: Path | None = None) -> list[TaskFile]:
     if not team_exists(team_name, base_dir):
         raise ValueError(f"Team {team_name!r} does not exist")
     team_dir = _tasks_dir(base_dir) / team_name
@@ -303,9 +360,7 @@ def list_tasks(
     return tasks
 
 
-def reset_owner_tasks(
-    team_name: str, agent_name: str, base_dir: Path | None = None
-) -> None:
+def reset_owner_tasks(team_name: str, agent_name: str, base_dir: Path | None = None) -> None:
     team_dir = _tasks_dir(base_dir) / team_name
     lock_path = team_dir / ".lock"
 
@@ -320,6 +375,4 @@ def reset_owner_tasks(
                 if task.status != "completed":
                     task.status = "pending"
                 task.owner = None
-                f.write_text(
-                    json.dumps(task.model_dump(by_alias=True, exclude_none=True))
-                )
+                f.write_text(json.dumps(task.model_dump(by_alias=True, exclude_none=True)))


### PR DESCRIPTION
## Summary
- Enable McCabe complexity check (`C90`) in ruff with `max-complexity=10`
- Refactor 5 functions that exceeded the threshold:
  - `messaging.read_inbox_filtered` (11 → ≤10): extract `_select_matching_indices`
  - `server.check_teammate` (11 → ≤10): extract `_check_tmux_status`
  - `server.send_message` (30 → ≤10): split into per-type handler functions + `_MESSAGE_HANDLERS` dispatch table
  - `spawner.spawn_teammate` (12 → ≤10): extract `_validate_spawn_args`, `_build_spawn_command`
  - `tasks.update_task` (58 → ≤10): decompose into 8 focused helpers (validate, apply, cleanup, write phases)

## Test plan
- [x] `ruff check --select C90 src/` passes with zero errors
- [x] All 207 existing tests pass (`pytest tests/ -x`)
- [ ] Verify no behavioral changes in team messaging, task management, and spawning workflows