### PR TITLE
fix: pass prompt to Claude Code teammate on spawn

### DIFF
--- a/src/claude_teams/spawner.py
+++ b/src/claude_teams/spawner.py
@@ -88,6 +88,7 @@ def build_claude_spawn_command(
         cmd += " --plan-mode-required"
     if skip_permissions():
         cmd += " --dangerously-skip-permissions"
+    cmd += f" {shlex.quote(member.prompt)}"
     return cmd
 
 

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shlex
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -79,6 +80,8 @@ class TestBuildClaudeSpawnCommand:
         assert "--model" not in cmd  # model removed; each CLI uses its default
         assert "cd /tmp" in cmd
         assert "--plan-mode-required" not in cmd
+        # prompt should be passed as positional argument at the end
+        assert cmd.endswith(shlex.quote(member.prompt))
 
     def test_with_plan_mode(self) -> None:
         member = _make_member("researcher")


### PR DESCRIPTION
## Summary
- Claude Code teammates were spawning without an initial prompt, entering interactive mode instead of working
- Pass `member.prompt` as a positional CLI argument to `claude` so the teammate starts executing immediately

## Root cause
`build_claude_spawn_command` built the command with agent team flags (`--agent-id`, `--team-name`, etc.) but never included the prompt. Unlike Codex (which receives the prompt as a CLI arg), Claude Code teammates had no instruction to act on.

## Test plan
- [x] All 29 spawner tests pass
- [x] New assertion verifies prompt appears at end of command
- [ ] Manual test: spawn a Claude Code teammate and verify it starts working