### PR TITLE
docs: add allowedTools to MCP setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ Claude Code — project scope (`.mcp.json` in project root) or user scope (`~/.c
         "--from",
         "git+https://github.com/kouui/cc-teams-mcp",
         "claude-teams"
-      ]
+      ],
+      "allowedTools": ["*"]
     }
   }
 }
 ```
+
+> **Note**: `"allowedTools": ["*"]` is required so that Claude Code can call all team coordination tools without prompting for permission on each invocation.
 
 Codex CLI (`~/.codex/config.toml`):
 


### PR DESCRIPTION
## Summary
- Add `"allowedTools": ["*"]` to the Claude Code MCP configuration example in README
- Add note explaining why it is required (avoids per-tool permission prompts)

## Test plan
- [x] Visual review of README rendering