### PR TITLE
fix: 修复 tmux send-keys 导致 Codex TUI 消息不提交

### DIFF
--- a/src/claude_teams/claude_side/injector.py
+++ b/src/claude_teams/claude_side/injector.py
@@ -31,8 +31,16 @@ def inject_message(pane_id: str, msg: InboxMessage) -> bool:
     text = format_message_for_injection(msg)
 
     try:
+        # Step 1: Send text literally (-l prevents key name interpretation)
         subprocess.run(
-            ["tmux", "send-keys", "-t", pane_id, text, "Enter"],
+            ["tmux", "send-keys", "-t", pane_id, "-l", text],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        # Step 2: Send Enter key separately (without -l so "Enter" is a key name)
+        subprocess.run(
+            ["tmux", "send-keys", "-t", pane_id, "Enter"],
             capture_output=True,
             text=True,
             check=True,


### PR DESCRIPTION
## 概要

修复 Claude → External Agent 消息注入时，文本出现在 Codex 输入框但未自动提交的问题。

### 问题原因

`tmux send-keys -t pane text Enter` 不带 `-l` 标志时，tmux 会把文本中的空格解释为多个按键的分隔符，导致：
- 消息内容被拆散成多个独立按键事件
- `Enter` 键可能在中间被消费，而非在文本末尾触发提交

### 修复方案

将单次 `send-keys` 拆为两步：
1. `tmux send-keys -t pane -l "text"` — literal 模式发送完整文本内容
2. `tmux send-keys -t pane Enter` — 单独发送 Enter 按键

### 实际测试

在真实 Claude Code 团队环境中验证：Claude team-lead 通过 MCP-A watcher 向 Codex CLI teammate 发送消息，消息成功输入并自动提交。

## 测试计划

- [x] 177 个单元测试全部通过
- [x] injector 测试更新为验证两步 send-keys 调用
- [x] 真实环境 Claude → Codex 消息注入验证