### PR TITLE
fix: send-keys 两步之间加延迟，修复 Codex TUI 消息提交问题

### DIFF
--- a/src/claude_teams/claude_side/injector.py
+++ b/src/claude_teams/claude_side/injector.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import time
 
 from claude_teams.common.models import InboxMessage
 
@@ -38,6 +39,8 @@ def inject_message(pane_id: str, msg: InboxMessage) -> bool:
             text=True,
             check=True,
         )
+        # Wait for TUI to render the input text before pressing Enter
+        time.sleep(0.5)
         # Step 2: Send Enter key separately (without -l so "Enter" is a key name)
         subprocess.run(
             ["tmux", "send-keys", "-t", pane_id, "Enter"],


### PR DESCRIPTION
## 概要

修复 tmux `send-keys` 两步发送（text + Enter）之间无延迟导致 Codex TUI 忽略 Enter 键的问题。

### 问题原因

Codex CLI 使用 React/Ink TUI 框架，文本通过 `send-keys -l` 输入后需要时间渲染到输入框。如果立即发送 `Enter`，TUI 尚未完成渲染，Enter 键被丢弃。

### 修复方案

在两步 `send-keys` 之间加入 `time.sleep(0.5)` 延迟：
```python
subprocess.run(["tmux", "send-keys", "-t", pane_id, "-l", text])  # 文本
time.sleep(0.5)  # 等待 TUI 渲染
subprocess.run(["tmux", "send-keys", "-t", pane_id, "Enter"])      # 提交
```

### 并发安全性

详见 #11 — 每个 external agent 单 watcher + 顺序注入 + file_lock，不需要额外锁机制。

## 测试计划

- [x] 177 个单元测试全部通过
- [x] tmux 真实环境手动验证：Python injector → Codex pane，消息成功提交