### PR TITLE
fix: chunk tmux send-keys to avoid >1024-byte truncation

### DIFF
--- a/src/claude_teams/claude_side/injector.py
+++ b/src/claude_teams/claude_side/injector.py
@@ -15,6 +15,14 @@ from claude_teams.common.models import InboxMessage
 
 logger = logging.getLogger(__name__)
 
+# tmux send-keys -l splits text into paste events at this boundary.
+# Codex TUI treats paste events >1024 bytes as "[Pasted Content]" and
+# refuses to submit them.  Keep chunks at or below this limit.
+_TMUX_SEND_KEYS_MAX = 1024
+
+# Short pause between chunks so the TUI can absorb each one.
+_CHUNK_DELAY = 0.2
+
 
 def format_message_for_injection(msg: InboxMessage) -> str:
     """Format an inbox message for tmux injection.
@@ -22,6 +30,20 @@ def format_message_for_injection(msg: InboxMessage) -> str:
     Returns plain text in the format: [Message from <sender>]: <content>
     """
     return f"[Message from {msg.from_}]: {msg.text}"
+
+
+def _send_text_chunked(pane_id: str, text: str) -> None:
+    """Send text to a tmux pane in chunks to avoid the 1024-byte paste limit."""
+    for offset in range(0, len(text), _TMUX_SEND_KEYS_MAX):
+        chunk = text[offset : offset + _TMUX_SEND_KEYS_MAX]
+        subprocess.run(
+            ["tmux", "send-keys", "-t", pane_id, "-l", chunk],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        if offset + _TMUX_SEND_KEYS_MAX < len(text):
+            time.sleep(_CHUNK_DELAY)
 
 
 def inject_message(pane_id: str, msg: InboxMessage) -> bool:
@@ -32,13 +54,8 @@ def inject_message(pane_id: str, msg: InboxMessage) -> bool:
     text = format_message_for_injection(msg)
 
     try:
-        # Step 1: Send text literally (-l prevents key name interpretation)
-        subprocess.run(
-            ["tmux", "send-keys", "-t", pane_id, "-l", text],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        # Step 1: Send text literally in chunks (-l prevents key name interpretation)
+        _send_text_chunked(pane_id, text)
         # Wait for TUI to render the input text before pressing Enter
         time.sleep(0.5)
         # Step 2: Send Enter key separately (without -l so "Enter" is a key name)


### PR DESCRIPTION
## Summary

- `tmux send-keys -l` splits text >1024 bytes into paste events, causing Codex TUI to display `[Pasted Content]` and refuse to submit
- Split long text into ≤1024-byte chunks with 0.2s delay between each, then send Enter
- Add test for chunked injection of long messages

## Test plan

- [x] Unit tests pass (`uv run pytest tests/test_injector.py -x`)
- [x] Manual verification: spawned Codex in tmux, confirmed 2837-char message injected and submitted successfully with chunked approach

Closes #13