### PR TITLE
fix: fallback to tmux new-session when no active session exists

### DIFF
--- a/tests/test_claude_side_server.py
+++ b/tests/test_claude_side_server.py
@@ -53,7 +53,7 @@ async def client(tmp_path: Path, monkeypatch):
     )
     monkeypatch.setattr(
         "claude_teams.claude_side.spawner.subprocess.run",
-        lambda *a, **kw: type("R", (), {"stdout": "%99\n"})(),
+        lambda *a, **kw: type("R", (), {"stdout": "%99\n", "returncode": 0})(),
     )
     (tmp_path / "teams").mkdir()
     (tmp_path / "tasks").mkdir()


### PR DESCRIPTION
Closes #15

## Summary

- `build_tmux_spawn_args()` now checks for active tmux sessions via `_has_tmux_session()`
- When no session exists, falls back to `tmux new-session -d` to create a detached session
- Allows spawning external agents from a plain bash shell (no tmux required)
- `kill-pane` automatically destroys the empty session on shutdown — no extra cleanup needed

## Changes

- **`src/claude_teams/claude_side/spawner.py`**: Added `_has_tmux_session()` helper and 3-tier fallback logic in `build_tmux_spawn_args()`
- **`tests/test_spawner.py`**: Added 7 tests for `TestBuildTmuxSpawnArgs` and `TestHasTmuxSession`
- **`tests/test_claude_side_server.py`**: Fixed mock to include `returncode` attribute

## Test plan

- [x] All 185 tests pass
- [x] Manually verified `tmux new-session -d` works without existing sessions
- [x] Verified `kill-pane` auto-cleans empty sessions