### PR TITLE
fix: remove hardcoded model from Gemini spawn command

### DIFF
--- a/src/claude_teams/claude_side/spawner.py
+++ b/src/claude_teams/claude_side/spawner.py
@@ -110,7 +110,6 @@ def build_spawn_command(backend_type: BackendType, binary: str, prompt: str, cwd
         return (
             f"cd {shlex.quote(cwd)} && "
             f"{shlex.quote(binary)} "
-            f"-m gemini-3.1-pro "
             f"--yolo "
             f"--screen-reader "
             f"--prompt-interactive {shlex.quote(prompt)}"

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -85,7 +85,7 @@ class TestBuildSpawnCommand:
     def test_gemini_format(self) -> None:
         cmd = build_spawn_command("gemini", "/usr/bin/gemini", "Do research", "/tmp/work")
         assert "/usr/bin/gemini" in cmd
-        assert "-m gemini-3.1-pro" in cmd
+        assert "-m " not in cmd  # no hardcoded model, use Gemini CLI default
         assert "--yolo" in cmd
         assert "--screen-reader" in cmd
         assert "--prompt-interactive" in cmd


### PR DESCRIPTION
## Summary

- Remove hardcoded `-m gemini-3.1-pro` from Gemini spawn command in `build_spawn_command()`
- Let Gemini CLI use its configured default model instead

## Why

When spawning Gemini agents in tmux with `--screen-reader` mode, the model `gemini-3.1-pro` is rejected with "Model not found or is invalid" error, even though it works in normal interactive mode. Removing the `-m` flag lets Gemini CLI use whatever model the user has configured as default.

## Changes

- `spawner.py`: Removed `-m gemini-3.1-pro` from Gemini spawn command
- `test_spawner.py`: Updated test to verify no hardcoded model flag

## Test plan

- [x] All 31 spawner tests pass
- [ ] Manual test: spawn Gemini agent in tmux and verify it starts without model error